### PR TITLE
show dropdown even when compare mode is not on, show the message on top of the map

### DIFF
--- a/src/pages/Explore/components/Map/index.tsx
+++ b/src/pages/Explore/components/Map/index.tsx
@@ -15,7 +15,7 @@ import {
   useUrlState,
   useSlider
 } from "./hooks";
-import { ZoomMessage, ExtentMessage } from "../controls/MapMessages";
+import { ZoomMessage, ExtentMessage, MapMessage } from "../controls/MapMessages";
 
 import PlaceSearchControl from "./components/PlaceSearch";
 import {
@@ -35,10 +35,10 @@ export const sliderMapContainerId: string = 'slider-map'
 const ExploreMap = () => {
   const mapRef = useRef<atlas.Map | null>(null);
   const { center, zoom} = useExploreSelector(s => s.map);
-  const { compareMode } = useExploreSelector(s => s.mosaic)
+  const { compareMode, queryToCompare, query } = useExploreSelector(s => s.mosaic)
   const [mapReady, setMapReady] = useState<boolean>(false);
   const mapHandlers = useMapEvents(mapRef);
-
+  const slider = useSlider(mapRef);
   // Initialize the map
   useEffect(() => {
     const onReady = () => setMapReady(true);
@@ -79,7 +79,6 @@ const ExploreMap = () => {
   useMosaicLayer(mapRef, mapReady);
   useZoomEvents(mapRef);
   useMapControls(mapRef, mapReady);
-  useSlider(mapRef);
   useUrlState();
 
   const { zoomToLayer, showZoomMsg } = useMapZoomToLayer();
@@ -87,14 +86,16 @@ const ExploreMap = () => {
 
   const { showExtentMsg, zoomToExtent } = useMapZoomToExtent(mapRef);
   const extentMsg = <ExtentMessage onClick={zoomToExtent} />;
+  const compareMsg = <MapMessage><span>{query.name} / {queryToCompare.name? queryToCompare.name : 'Not selected'}</span></MapMessage>
   const loadingIndicator = (
     <ProgressIndicator barHeight={1} styles={progressIndicatorStyles} />
   );
 
   return (
     <div style={mapContainerStyle}>
-      {mapHandlers.areTilesLoading && loadingIndicator}
+      {(mapHandlers.areTilesLoading || slider.areTilesToCompareLoading) && loadingIndicator}
       {showZoomMsg && zoomMsg}
+      {!showZoomMsg && compareMode && compareMsg}
       {showExtentMsg && extentMsg}
       <PlaceSearchControl mapRef={mapRef} />
       <MapSettingsControl mapRef={mapRef} />

--- a/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
@@ -86,7 +86,12 @@ const SearchResultsPane = ({
   return (
     <>
       <Separator />
-      {mosaicOption.length > 1 && <><CompareButton />       <Separator /></>}
+      {mosaicOption.length > 1 && 
+        <>
+          <CompareButton /> 
+          <MosaicPresetToCompare /> 
+          <Separator />
+        </>}
       {!compareMode && 
             <>
         <SearchResultsHeader results={data} isLoading={isPreviousData} />
@@ -113,7 +118,6 @@ const SearchResultsPane = ({
         <ExploreInHub />
         </>
       }
-      {compareMode && <MosaicPresetToCompare />}
     </>
   );
 };

--- a/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
@@ -5,7 +5,7 @@ import { setMosaicToCompareQuery } from "../../../state/mosaicSlice";
 import StateSelector from "./StateSelector";
 
 const MosaicPresetToCompareSelector = () => {
-  const { collection, queryToCompare, mosaicOption } = useExploreSelector(state => state.mosaic);
+  const { collection, queryToCompare, mosaicOption, compareMode } = useExploreSelector(state => state.mosaic);
   const mosaics = mosaicOption
 
   const mosaicOptions =
@@ -27,7 +27,7 @@ const MosaicPresetToCompareSelector = () => {
       options={mosaicOptions}
       selectedKey={queryToCompare.name}
       getStateValFn={getQueryPresetByName}
-      disabled={!collection?.id}
+      disabled={!compareMode}
       cyId="mosaic-selector"
     />
   );

--- a/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
@@ -5,7 +5,7 @@ import { setMosaicToCompareQuery } from "../../../state/mosaicSlice";
 import StateSelector from "./StateSelector";
 
 const MosaicPresetToCompareSelector = () => {
-  const { collection, queryToCompare, mosaicOption, compareMode } = useExploreSelector(state => state.mosaic);
+  const { queryToCompare, mosaicOption, compareMode } = useExploreSelector(state => state.mosaic);
   const mosaics = mosaicOption
 
   const mosaicOptions =

--- a/src/pages/Explore/components/controls/MapMessages.tsx
+++ b/src/pages/Explore/components/controls/MapMessages.tsx
@@ -5,7 +5,7 @@ interface MessageProps {
   onClick: () => void;
 }
 
-const MapMessage: React.FC = ({ children }) => {
+export const MapMessage: React.FC = ({ children }) => {
   const theme = useTheme();
 
   return (

--- a/src/pages/Explore/state/mapSlice.ts
+++ b/src/pages/Explore/state/mapSlice.ts
@@ -20,7 +20,7 @@ export interface MapState {
 }
 
 const initialState: MapState = {
-  center: center || [30, 30],
+  center: center || [-168.16047115799995, -14.520928643999966],
   zoom: zoom || 2,
   bounds: null,
   boundaryShape: null,

--- a/src/pages/Explore/state/mapSlice.ts
+++ b/src/pages/Explore/state/mapSlice.ts
@@ -20,7 +20,7 @@ export interface MapState {
 }
 
 const initialState: MapState = {
-  center: center || [-168.16047115799995, -14.520928643999966],
+  center: center || [30, 30],
   zoom: zoom || 2,
   bounds: null,
   boundaryShape: null,


### PR DESCRIPTION
Shows the dropdown for queries to compare even when 'compare mode' is off. (in disabled state.) Ricardo suggested to cut down one step and just get rid of on/off switch (and replace it with preset query selector.) But then it opens more questions like how can we turn off the compare mode. so I kind of took this approach.
![Screen Shot 2021-12-09 at 2 34 11 PM](https://user-images.githubusercontent.com/4583806/145463818-9acd29d2-4c7a-4d18-9d16-a1c247bfe695.png)

Shows the message shows the current query name/ the name of query to compare. Other messages (zoom, data extent) about map take priority over this message. ex. if the explorer is not zoomed enough, this query message won't be displayed. 

![Screen Shot 2021-12-09 at 2 34 20 PM](https://user-images.githubusercontent.com/4583806/145464129-bdc31836-8805-4e6c-b914-bd2d1e32bf18.png)

![Screen Shot 2021-12-09 at 2 35 15 PM](https://user-images.githubusercontent.com/4583806/145464307-86cf6660-5919-4896-b45a-a05e07f39f89.png)


It is a subtle change, but I also made progress bar to reflect the tile loading status of slider map. so if slider map is loading the tiles, the progress bar will be displayed. 
