### PR TITLE
set default view using center and zoom instead of bbox

### DIFF
--- a/src/pages/Explore/state/mapSlice.ts
+++ b/src/pages/Explore/state/mapSlice.ts
@@ -5,8 +5,6 @@ import { getCenterAndZoomQueryString } from "../utils";
 import { setShowAsLayer } from "./detailSlice";
 
 const { center, zoom } = getCenterAndZoomQueryString();
-// manually setting bbox for pacific islands
-const defaultBbox = [ 139.70214843749997, -29.08001067499991, 180.263671875, 20.555405992000132 ]
 export interface MapState {
   center: [number, number];
   zoom: number;
@@ -21,9 +19,9 @@ export interface MapState {
 }
 
 const initialState: MapState = {
-  center: center || [30, 30],
-  zoom: zoom || 2,
-  bounds: defaultBbox,
+  center: center || [177.221875, 1.9332268264771233],
+  zoom: zoom || 3 ,
+  bounds: null,
   boundaryShape: null,
   showCollectionOutline: true,
   showSidebar: true,


### PR DESCRIPTION
There was a bug that default view with bbox overrides center and zoom query. (and we need this functionality to fit selected mosaic boundary I belive.) This PR changes how we set up the default view so it doesn't conflict with query parameter.