### PR TITLE
Add DEP data

### DIFF
--- a/public/data/dep-data.json
+++ b/public/data/dep-data.json
@@ -1,0 +1,405 @@
+{
+  "id": "sentinel-2-cloudless",
+  "type": "Collection",
+  "links": [
+      {
+          "rel": "items",
+          "type": "application/geo+json",
+          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/collections/aster-l1t/items"
+      },
+      {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
+      },
+      {
+          "rel": "root",
+          "type": "application/json",
+          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
+      },
+      {
+          "rel": "self",
+          "type": "application/json",
+          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/collections/aster-l1t"
+      },
+      {
+          "rel": "describedby",
+          "href": "https://planetarycomputer.microsoft.com/aster-l1t",
+          "title": "Human readable dataset overview and reference",
+          "type": "text/html"
+      }
+  ],
+  "title": "Sentinel 2 Cloudless (Monthly)",
+  "assets": {
+      "thumbnail": {
+          "href": "https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/aster.png",
+          "type": "image/png",
+          "roles": [
+              "thumbnail"
+          ],
+          "title": "ASTER L1T"
+      }
+  },
+  "extent": {
+      "spatial": {
+          "bbox": [
+              [
+                  -180,
+                  -90,
+                  180,
+                  90
+              ]
+          ]
+      },
+      "temporal": {
+          "interval": [
+              [
+                  "2000-03-04T12:00:00.000000Z",
+                  "2006-12-31T12:00:00.000000Z"
+              ]
+          ]
+      }
+  },
+  "license": "proprietary",
+  "keywords": [
+      "dep"
+  ],
+  "providers": [
+      {
+          "url": "https://terra.nasa.gov/about/terra-instruments/aster",
+          "name": "NASA",
+          "roles": [
+              "producer",
+              "licensor"
+          ]
+      },
+      {
+          "url": "https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/aster-overview/",
+          "name": "USGS",
+          "roles": [
+              "processor",
+              "producer",
+              "licensor"
+          ]
+      },
+      {
+          "url": "https://planetarycomputer.microsoft.com",
+          "name": "Microsoft",
+          "roles": [
+              "host",
+              "processor"
+          ]
+      }
+  ],
+  "summaries": {
+      "gsd": [
+          15,
+          30,
+          90
+      ],
+      "eo:bands": [
+          {
+              "gsd": 15,
+              "name": "VNIR_Band1",
+              "common_name": "green",
+              "description": "visible yellow/green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.08
+          },
+          {
+              "gsd": 15,
+              "name": "VNIR_Band2",
+              "common_name": "red",
+              "description": "visible red",
+              "center_wavelength": 0.66,
+              "full_width_half_max": 0.06
+          },
+          {
+              "gsd": 15,
+              "name": "VNIR_Band3N",
+              "common_name": "nir08",
+              "description": "near infrared",
+              "center_wavelength": 0.82,
+              "full_width_half_max": 0.08
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band4",
+              "common_name": "swir16",
+              "description": "short-wave infrared",
+              "center_wavelength": 1.65,
+              "full_width_half_max": 0.1
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band5",
+              "common_name": "swir22",
+              "description": "short-wave infrared",
+              "center_wavelength": 2.165,
+              "full_width_half_max": 0.04
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band6",
+              "common_name": "swir22",
+              "description": "short-wave infrared",
+              "center_wavelength": 2.205,
+              "full_width_half_max": 0.04
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band7",
+              "common_name": "swir22",
+              "description": "short-wave infrared",
+              "center_wavelength": 2.26,
+              "full_width_half_max": 0.05
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band8",
+              "description": "short-wave infrared",
+              "center_wavelength": 2.339,
+              "full_width_half_max": 0.07
+          },
+          {
+              "gsd": 30,
+              "name": "SWIR_Band9",
+              "description": "short-wave infrared",
+              "center_wavelength": 2.395,
+              "full_width_half_max": 0.07
+          },
+          {
+              "gsd": 90,
+              "name": "TIR_Band10",
+              "common_name": "lwir",
+              "description": "thermal infrared",
+              "center_wavelength": 8.3,
+              "full_width_half_max": 0.35
+          },
+          {
+              "gsd": 90,
+              "name": "TIR_Band11",
+              "common_name": "lwir",
+              "description": "thermal infrared",
+              "center_wavelength": 8.65,
+              "full_width_half_max": 0.35
+          },
+          {
+              "gsd": 90,
+              "name": "TIR_Band12",
+              "common_name": "lwir",
+              "description": "thermal infrared",
+              "center_wavelength": 9.11,
+              "full_width_half_max": 0.35
+          },
+          {
+              "gsd": 90,
+              "name": "TIR_Band13",
+              "common_name": "lwir",
+              "description": "thermal infrared",
+              "center_wavelength": 10.6,
+              "full_width_half_max": 0.7
+          },
+          {
+              "gsd": 90,
+              "name": "TIR_Band14",
+              "common_name": "lwir",
+              "description": "thermal infrared",
+              "center_wavelength": 11.3,
+              "full_width_half_max": 0.7
+          }
+      ],
+      "platform": [
+          "terra"
+      ],
+      "instruments": [
+          "aster"
+      ]
+  },
+  "description": "The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\\n\\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\\n",
+  "item_assets": {
+      "TIR": {
+          "roles": [
+              "data"
+          ],
+          "title": "TIR Swath data",
+          "eo:bands": [
+              {
+                  "gsd": 90,
+                  "name": "TIR_Band10",
+                  "common_name": "lwir",
+                  "description": "thermal infrared",
+                  "center_wavelength": 8.3,
+                  "full_width_half_max": 0.35
+              },
+              {
+                  "gsd": 90,
+                  "name": "TIR_Band11",
+                  "common_name": "lwir",
+                  "description": "thermal infrared",
+                  "center_wavelength": 8.65,
+                  "full_width_half_max": 0.35
+              },
+              {
+                  "gsd": 90,
+                  "name": "TIR_Band12",
+                  "common_name": "lwir",
+                  "description": "thermal infrared",
+                  "center_wavelength": 9.11,
+                  "full_width_half_max": 0.35
+              },
+              {
+                  "gsd": 90,
+                  "name": "TIR_Band13",
+                  "common_name": "lwir",
+                  "description": "thermal infrared",
+                  "center_wavelength": 10.6,
+                  "full_width_half_max": 0.7
+              },
+              {
+                  "gsd": 90,
+                  "name": "TIR_Band14",
+                  "common_name": "lwir",
+                  "description": "thermal infrared",
+                  "center_wavelength": 11.3,
+                  "full_width_half_max": 0.7
+              }
+          ]
+      },
+      "xml": {
+          "type": "application/xml",
+          "roles": [
+              "metadata"
+          ],
+          "title": "XML metadata"
+      },
+      "SWIR": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data"
+          ],
+          "title": "SWIR Swath data",
+          "eo:bands": [
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band4",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 1.65,
+                  "full_width_half_max": 0.1
+              },
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band5",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 2.165,
+                  "full_width_half_max": 0.04
+              },
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band6",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 2.205,
+                  "full_width_half_max": 0.04
+              },
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band7",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 2.26,
+                  "full_width_half_max": 0.05
+              },
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band8",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 2.339,
+                  "full_width_half_max": 0.07
+              },
+              {
+                  "gsd": 30,
+                  "name": "SWIR_Band9",
+                  "common_name": "swir",
+                  "description": "short-wave infrared",
+                  "center_wavelength": 2.395,
+                  "full_width_half_max": 0.07
+              }
+          ]
+      },
+      "VNIR": {
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": [
+              "data"
+          ],
+          "title": "VNIR Swath data",
+          "eo:bands": [
+              {
+                  "gsd": 15,
+                  "name": "VNIR_Band1",
+                  "common_name": "yellow/green",
+                  "description": "visible yellow/green",
+                  "center_wavelength": 0.56,
+                  "full_width_half_max": 0.08
+              },
+              {
+                  "gsd": 15,
+                  "name": "VNIR_Band2",
+                  "common_name": "red",
+                  "description": "visible red",
+                  "center_wavelength": 0.66,
+                  "full_width_half_max": 0.06
+              },
+              {
+                  "gsd": 15,
+                  "name": "VNIR_Band3N",
+                  "common_name": "near infrared",
+                  "description": "near infrared",
+                  "center_wavelength": 0.82,
+                  "full_width_half_max": 0.08
+              }
+          ]
+      },
+      "qa-txt": {
+          "type": "text/plain",
+          "roles": [
+              "metadata"
+          ],
+          "title": "QA browse file",
+          "description": "Geometric quality assessment report."
+      },
+      "qa-browse": {
+          "type": "image/jpeg",
+          "roles": [
+              "thumbnail"
+          ],
+          "title": "QA browse file",
+          "description": "Single-band black and white reduced resolution browse overlaid with red, green, and blue (RGB) markers for GCPs used during the geometric verification quality check."
+      },
+      "tir-browse": {
+          "type": "image/jpeg",
+          "roles": [
+              "thumbnail"
+          ],
+          "title": "Standalone reduced resolution TIR"
+      },
+      "vnir-browse": {
+          "type": "image/jpeg",
+          "roles": [
+              "thumbnail"
+          ],
+          "title": "VNIR browse file",
+          "description": "Standalone reduced resolution VNIR"
+      }
+  },
+  "stac_version": "1.0.0",
+  "msft:container": "aster",
+  "stac_extensions": [
+      "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+  ],
+  "msft:storage_account": "astersa",
+  "msft:short_description": "The ASTER instrument, launched on-board NASA's Terra satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  This dataset contains ASTER data from 2000-2006."
+}

--- a/public/data/dep-data.json
+++ b/public/data/dep-data.json
@@ -43,12 +43,7 @@
   "extent": {
       "spatial": {
           "bbox": [
-              [
-                  -180,
-                  -90,
-                  180,
-                  90
-              ]
+            [ 139.70214843749997, -29.08001067499991, 180.263671875, 20.555405992000132 ]
           ]
       },
       "temporal": {
@@ -401,5 +396,5 @@
       "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
   ],
   "msft:storage_account": "astersa",
-  "msft:short_description": "The ASTER instrument, launched on-board NASA's Terra satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  This dataset contains ASTER data from 2000-2006."
+  "msft:short_description": "DEP data"
 }

--- a/public/data/dep-data.json
+++ b/public/data/dep-data.json
@@ -1,45 +1,9 @@
 {
   "id": "sentinel-2-cloudless",
   "type": "Collection",
-  "links": [
-      {
-          "rel": "items",
-          "type": "application/geo+json",
-          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/collections/aster-l1t/items"
-      },
-      {
-          "rel": "parent",
-          "type": "application/json",
-          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
-      },
-      {
-          "rel": "root",
-          "type": "application/json",
-          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/"
-      },
-      {
-          "rel": "self",
-          "type": "application/json",
-          "href": "https://planetarycomputer-staging.microsoft.com/api/stac/v1/collections/aster-l1t"
-      },
-      {
-          "rel": "describedby",
-          "href": "https://planetarycomputer.microsoft.com/aster-l1t",
-          "title": "Human readable dataset overview and reference",
-          "type": "text/html"
-      }
-  ],
+  "links": [],
   "title": "Sentinel 2 Cloudless (Monthly)",
-  "assets": {
-      "thumbnail": {
-          "href": "https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/aster.png",
-          "type": "image/png",
-          "roles": [
-              "thumbnail"
-          ],
-          "title": "ASTER L1T"
-      }
-  },
+  "assets": { },
   "extent": {
       "spatial": {
           "bbox": [
@@ -49,8 +13,8 @@
       "temporal": {
           "interval": [
               [
-                  "2000-03-04T12:00:00.000000Z",
-                  "2006-12-31T12:00:00.000000Z"
+                  "2020-09-01T12:00:00.000000Z",
+                  "2020-12-01T12:00:00.000000Z"
               ]
           ]
       }
@@ -61,31 +25,13 @@
   ],
   "providers": [
       {
-          "url": "https://terra.nasa.gov/about/terra-instruments/aster",
-          "name": "NASA",
+          "url": "https://www.spc.int/DigitalEarthPacific",
+          "name": "DEP",
           "roles": [
               "producer",
               "licensor"
           ]
-      },
-      {
-          "url": "https://lpdaac.usgs.gov/data/get-started-data/collection-overview/missions/aster-overview/",
-          "name": "USGS",
-          "roles": [
-              "processor",
-              "producer",
-              "licensor"
-          ]
-      },
-      {
-          "url": "https://planetarycomputer.microsoft.com",
-          "name": "Microsoft",
-          "roles": [
-              "host",
-              "processor"
-          ]
-      }
-  ],
+      }],
   "summaries": {
       "gsd": [
           15,
@@ -93,116 +39,6 @@
           90
       ],
       "eo:bands": [
-          {
-              "gsd": 15,
-              "name": "VNIR_Band1",
-              "common_name": "green",
-              "description": "visible yellow/green",
-              "center_wavelength": 0.56,
-              "full_width_half_max": 0.08
-          },
-          {
-              "gsd": 15,
-              "name": "VNIR_Band2",
-              "common_name": "red",
-              "description": "visible red",
-              "center_wavelength": 0.66,
-              "full_width_half_max": 0.06
-          },
-          {
-              "gsd": 15,
-              "name": "VNIR_Band3N",
-              "common_name": "nir08",
-              "description": "near infrared",
-              "center_wavelength": 0.82,
-              "full_width_half_max": 0.08
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band4",
-              "common_name": "swir16",
-              "description": "short-wave infrared",
-              "center_wavelength": 1.65,
-              "full_width_half_max": 0.1
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band5",
-              "common_name": "swir22",
-              "description": "short-wave infrared",
-              "center_wavelength": 2.165,
-              "full_width_half_max": 0.04
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band6",
-              "common_name": "swir22",
-              "description": "short-wave infrared",
-              "center_wavelength": 2.205,
-              "full_width_half_max": 0.04
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band7",
-              "common_name": "swir22",
-              "description": "short-wave infrared",
-              "center_wavelength": 2.26,
-              "full_width_half_max": 0.05
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band8",
-              "description": "short-wave infrared",
-              "center_wavelength": 2.339,
-              "full_width_half_max": 0.07
-          },
-          {
-              "gsd": 30,
-              "name": "SWIR_Band9",
-              "description": "short-wave infrared",
-              "center_wavelength": 2.395,
-              "full_width_half_max": 0.07
-          },
-          {
-              "gsd": 90,
-              "name": "TIR_Band10",
-              "common_name": "lwir",
-              "description": "thermal infrared",
-              "center_wavelength": 8.3,
-              "full_width_half_max": 0.35
-          },
-          {
-              "gsd": 90,
-              "name": "TIR_Band11",
-              "common_name": "lwir",
-              "description": "thermal infrared",
-              "center_wavelength": 8.65,
-              "full_width_half_max": 0.35
-          },
-          {
-              "gsd": 90,
-              "name": "TIR_Band12",
-              "common_name": "lwir",
-              "description": "thermal infrared",
-              "center_wavelength": 9.11,
-              "full_width_half_max": 0.35
-          },
-          {
-              "gsd": 90,
-              "name": "TIR_Band13",
-              "common_name": "lwir",
-              "description": "thermal infrared",
-              "center_wavelength": 10.6,
-              "full_width_half_max": 0.7
-          },
-          {
-              "gsd": 90,
-              "name": "TIR_Band14",
-              "common_name": "lwir",
-              "description": "thermal infrared",
-              "center_wavelength": 11.3,
-              "full_width_half_max": 0.7
-          }
       ],
       "platform": [
           "terra"
@@ -211,7 +47,7 @@
           "aster"
       ]
   },
-  "description": "The [ASTER](https://terra.nasa.gov/about/terra-instruments/aster) instrument, launched on-board NASA's [Terra](https://terra.nasa.gov/) satellite in 1999, provides multispectral images of the Earth at 15m-90m resolution.  ASTER images provide information about land surface temperature, color, elevation, and mineral composition.\\n\\nThis dataset represents ASTER [L1T](https://lpdaac.usgs.gov/products/ast_l1tv003/) data from 2000-2006.  L1T images have been terrain-corrected and rotated to a north-up UTM projection.  Images are in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.\\n",
+  "description": "DEP data",
   "item_assets": {
       "TIR": {
           "roles": [

--- a/public/stac/sentinel-2-cloudless/mosaicInfo.json
+++ b/public/stac/sentinel-2-cloudless/mosaicInfo.json
@@ -1,0 +1,33 @@
+{
+  "mosaics": [
+    {
+      "name": "2020 September",
+      "description": "",
+      "dep": true,
+      "tif": "https://deppcpublicstorage.blob.core.windows.net/output/demo/s2cloudless/s2-cloudless-sep2020.tif",
+      "cql": [
+        { "lte": [{ "property": "datetime" }, "2006-12-31"] },
+        { "lte": [{ "property": "eo:cloud_cover" }, 10] }
+      ]
+    },
+    {
+      "name": "2020 December",
+      "description": "",
+      "dep": true,
+      "tif": "https://deppcpublicstorage.blob.core.windows.net/output/demo/s2cloudless/s2-cloudless-dec2020.tif",
+      "cql": []
+    }
+  ],
+  "renderOptions": [
+    {
+      "name": "4 Band RGB Images",
+      "description": "4 band RGB Images",
+      "options": "assets=SWIR&bidx=1,3,5&nodata=0&skipcovered=False&exitwhenfull=False&items_limit=15&time_limit=5&color_formula=gamma RGB 2.7, saturation 1.2, sigmoidal RGB 15 0.55",
+      "minZoom": 9
+    }
+  ],
+  "defaultLocation": {
+    "zoom": 9,
+    "coordinates": [177.221875, 1.9332268264771233]
+  }
+}

--- a/public/stac/sentinel-2-cloudless/mosaicInfo.json
+++ b/public/stac/sentinel-2-cloudless/mosaicInfo.json
@@ -6,8 +6,7 @@
       "dep": true,
       "tif": "https://deppcpublicstorage.blob.core.windows.net/output/demo/s2cloudless/s2-cloudless-sep2020.tif",
       "cql": [
-        { "lte": [{ "property": "datetime" }, "2006-12-31"] },
-        { "lte": [{ "property": "eo:cloud_cover" }, 10] }
+        { "lte": [{ "property": "datetime" }, "2020-09-01"] }
       ]
     },
     {
@@ -15,7 +14,9 @@
       "description": "",
       "dep": true,
       "tif": "https://deppcpublicstorage.blob.core.windows.net/output/demo/s2cloudless/s2-cloudless-dec2020.tif",
-      "cql": []
+      "cql": [
+        { "lte": [{ "property": "datetime" }, "2020-12-01"] }
+      ]
     }
   ],
   "renderOptions": [
@@ -23,11 +24,11 @@
       "name": "4 Band RGB Images",
       "description": "4 band RGB Images",
       "options": "assets=SWIR&bidx=1,3,5&nodata=0&skipcovered=False&exitwhenfull=False&items_limit=15&time_limit=5&color_formula=gamma RGB 2.7, saturation 1.2, sigmoidal RGB 15 0.55",
-      "minZoom": 9
+      "minZoom": 3
     }
   ],
   "defaultLocation": {
-    "zoom": 9,
+    "zoom": 3,
     "coordinates": [177.221875, 1.9332268264771233]
   }
 }

--- a/src/config/datasets.yml
+++ b/src/config/datasets.yml
@@ -31,6 +31,14 @@
 
 ---
 collections:
+  sentinel-2-cloudless:
+    category: DEP data
+    headerImg: ./images/threedep-seamless-hero.png
+    tabs:
+      - title: Example Notebook
+        src: 3dep-seamless-example.html
+        launch: datasets/dep/3dep-seamless-example.ipynb
+
   3dep-seamless:
     category: DEMs
     headerImg: ./images/threedep-seamless-hero.png

--- a/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
+++ b/src/pages/Explore/components/Sidebar/panes/SearchResultsPane.tsx
@@ -64,7 +64,8 @@ const SearchResultsPane = ({
       <Spinner />
     </>
   );
-
+  // Hide hub button if selected collection is dep data (Sentinel 2 cloudless)
+  const hubButton = (collection?.id === 'sentinel-2-cloudless')? (<></>) : (<ExploreInHub />)
   // The logic here is complex.
   // If the collection has changed, and the new collection exists, and the query is returning previous results,
   // don't render the previous results while the new ones are fetched. Show a loading indicator.
@@ -110,7 +111,7 @@ const SearchResultsPane = ({
             />
           </FocusZone>
         </div>
-        <ExploreInHub />
+        {hubButton}
         </>
       }
       {compareMode && <MosaicPresetToCompare />}

--- a/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
@@ -13,11 +13,12 @@ import { isValidExplorer } from "utils/collections";
 
 const CollectionSelector = () => {
   const { isSuccess, data } = useCollections();
-  const collections: IStacCollection[] = data?.collections!;
-  const collection = useExploreSelector(state => state.mosaic.collection)
+  const collections: IStacCollection[] = data?.collections;
+  const collection = useExploreSelector(state => state.mosaic.collection);
+
   // Sets selector values based off of url state
   useCollectionUrlState(collections);
-  
+
   const collectionOptions = isSuccess ? sortedOptions(collections) : [];
 
   const getCollectionById = (key: string | number) => {

--- a/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
@@ -13,12 +13,11 @@ import { isValidExplorer } from "utils/collections";
 
 const CollectionSelector = () => {
   const { isSuccess, data } = useCollections();
-  const collections: IStacCollection[] = data?.collections;
-  const collection = useExploreSelector(state => state.mosaic.collection);
-
+  const collections: IStacCollection[] = data?.collections!;
+  const collection = useExploreSelector(state => state.mosaic.collection)
   // Sets selector values based off of url state
   useCollectionUrlState(collections);
-
+  
   const collectionOptions = isSuccess ? sortedOptions(collections) : [];
 
   const getCollectionById = (key: string | number) => {

--- a/src/pages/Explore/types.d.ts
+++ b/src/pages/Explore/types.d.ts
@@ -11,6 +11,8 @@ export interface IMosaicInfo {
 export interface IMosaic {
   name: string | null;
   description: string | null;
+  dep?: bool | null;
+  tif?: string | null;
   cql: [] | null;
   sortby: [] | null;
   hash?: string | null;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -173,6 +173,11 @@ export const makeTileJsonUrl = (
   const renderParams = encodeRenderOpts(renderOption?.options);
   const format = renderOption?.options.includes("format") ? "" : "&format=png";
 
+  // hard code tile url for dep data
+  if (query.dep) {
+    return `http://dep-pctitiler.westeurope.cloudapp.azure.com/cog/tiles/{z}/{x}/{y}.png?url=${query.tif}&bidx=1&bidx=2&bidx=3&nodata=0&unscale=false&resampling=nearest&max_size=1024&return_mask=true`
+  }
+
   // Rendering a single Item
   if (item && collection) {
     const forcePngRenderParams = renderParams.replace("jpg", "png");

--- a/src/utils/requests.js
+++ b/src/utils/requests.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { makeFilterBody } from "pages/Explore/utils/hooks/useStacFilter";
 import { collectionFilter } from "pages/Explore/utils/stac";
-import { useQuery, useQueries } from "react-query";
+import { useQuery } from "react-query";
 import { makeTileJsonUrl } from "utils";
 import { DATA_URL, STAC_URL } from "./constants";
 

--- a/src/utils/requests.js
+++ b/src/utils/requests.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { makeFilterBody } from "pages/Explore/utils/hooks/useStacFilter";
 import { collectionFilter } from "pages/Explore/utils/stac";
-import { useQuery } from "react-query";
+import { useQuery, useQueries } from "react-query";
 import { makeTileJsonUrl } from "utils";
 import { DATA_URL, STAC_URL } from "./constants";
 
@@ -57,8 +57,15 @@ const getCollections = async ({ queryKey }) => {
   // eslint-disable-next-line
   const [_key, collectionsUrl] = queryKey;
   const resp = await axios.get(`${collectionsUrl}/collections`);
-  return resp.data;
+  // sneak in dep data
+  const depResp = await axios.get(`/data/dep-data.json`);
+  const mergedData = {
+    ...resp.data,
+    collections: [...resp.data.collections, depResp.data]
+  }
+  return mergedData;
 };
+
 
 const getStaticMetadata = async ({ queryKey }) => {
   const [file] = queryKey;


### PR DESCRIPTION
- Add DEP data 
- `public/data/dep-data.json` is placed to work as a stac catalogue endpoint for DEP data. I copied one of collections from  Microsoft Planetary Computer catalogue, and replaced the data as much as I can. (but there are still some left over of the original data that I couldn't get rid of.)
- `public/stac/sentinel-2-cloudless/mosaicInfo.json` is similar in a way that is copied from one of other mosaic preset, edited as needed. 
- Hide 'explore in Hub' button for DEP data 

Screenshot of when 'compare mode' is on for DEP product
![Screen Shot 2021-12-13 at 11 17 57 AM](https://user-images.githubusercontent.com/4583806/145848600-e1598564-eda4-41cf-b362-941338b2ae82.png)
