### PR TITLE
show month name instead of season name

### DIFF
--- a/src/pages/Explore/components/Sidebar/selectors/MosaicPresetSelector.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/MosaicPresetSelector.tsx
@@ -1,10 +1,12 @@
 import { IDropdownOption } from "@fluentui/react";
 import { useEffect } from "react";
 import { useCollectionMosaicInfo } from "../../../utils/hooks";
+import { getAlternativeNameForMosaic } from "../../../utils/stac";
 import { useExploreDispatch, useExploreSelector } from "../../../state/hooks";
 import { setMosaicQuery, setMosaicOption } from "../../../state/mosaicSlice";
 import StateSelector from "./StateSelector";
 import { useMosaicUrlState } from "./hooks/useUrlState";
+
 
 const MosaicPresetSelector = () => {
   const { collection, query } = useExploreSelector(state => state.mosaic);
@@ -24,7 +26,7 @@ const MosaicPresetSelector = () => {
   const mosaicOptions =
     isSuccess && mosaicInfo?.mosaics
       ? mosaicInfo.mosaics.map((mosaic): IDropdownOption => {
-          return { key: mosaic.name || "", text: mosaic.name || "" };
+          return { key: mosaic.name || "", text: getAlternativeNameForMosaic(mosaic) || "" };
         })
       : [];
 

--- a/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/MosaicPresetToCompare.tsx
@@ -1,5 +1,5 @@
 import { IDropdownOption } from "@fluentui/react";
-
+import { getAlternativeNameForMosaic } from "../../../utils/stac";
 import { useExploreSelector } from "../../../state/hooks";
 import { setMosaicToCompareQuery } from "../../../state/mosaicSlice";
 import StateSelector from "./StateSelector";
@@ -11,7 +11,7 @@ const MosaicPresetToCompareSelector = () => {
   const mosaicOptions =
     mosaics.length
       ? mosaics.map((mosaic): IDropdownOption => {
-          return { key: mosaic.name || "", text: mosaic.name || "" };
+          return { key: mosaic.name || "", text: getAlternativeNameForMosaic(mosaic) || "" };
         })
       : [];
 

--- a/src/pages/Explore/utils/stac.ts
+++ b/src/pages/Explore/utils/stac.ts
@@ -3,6 +3,7 @@ import bboxToPolygon from "@turf/bbox-polygon";
 import { BBox } from "geojson";
 
 import { IStacFilterCollection, IStacFilterGeom } from "types/stac";
+const seasons = ['Spring', 'Summer', 'Fall', 'Winter']
 
 export const collectionFilter = (
   collectionId: string | undefined
@@ -28,3 +29,28 @@ export const geomFilter = (
     ],
   };
 };
+
+export const getAlternativeNameForMosaic =  function (mosaic: any) {
+  const seasonName = seasons.filter(e => mosaic.name.includes(e))
+  // If there is no season name in mosaic name, just return the name
+  if (seasonName.length === 0) return mosaic.name
+  else {
+    const cql = mosaic.cql
+    const anyInteracts = 'anyinteracts'
+    const dateTime = cql.map((element: any) => {
+      if (Object.keys(element).includes(anyInteracts)) {
+        return element[anyInteracts][1]
+      } else return false
+    }).filter((e:any) => e)
+    const month = dateTime.map((dateElements: any) => {
+      const eachMonth = dateElements.map((dateString:string) => {
+        const yyyymmdd = dateString.split('-')
+        const date = new Date(parseInt(yyyymmdd[0]), parseInt(yyyymmdd[1]), parseInt(yyyymmdd[2]));
+        const monthName = date.toLocaleString('default', { month: 'short' });
+        return monthName
+      })
+      return eachMonth.join(' - ')
+    })
+    return mosaic.name.replace(seasonName[0], month)
+  }
+}

--- a/src/pages/Explore/utils/stac.ts
+++ b/src/pages/Explore/utils/stac.ts
@@ -45,7 +45,7 @@ export const getAlternativeNameForMosaic =  function (mosaic: any) {
     const month = dateTime.map((dateElements: any) => {
       const eachMonth = dateElements.map((dateString:string) => {
         const yyyymmdd = dateString.split('-')
-        const date = new Date(parseInt(yyyymmdd[0]), parseInt(yyyymmdd[1]), parseInt(yyyymmdd[2]));
+        const date = new Date(parseInt(yyyymmdd[0]), parseInt(yyyymmdd[1]) - 1, parseInt(yyyymmdd[2]));
         const monthName = date.toLocaleString('default', { month: 'short' });
         return monthName
       })


### PR DESCRIPTION
The Season name doesn't really work for southern hemisphere. Replace the season name to month name

![Screen Shot 2021-12-14 at 4 36 44 PM](https://user-images.githubusercontent.com/4583806/146083970-6ee6db1d-8db0-48a7-b34d-bd8f63359f91.png)
