### PR TITLE
 Set an explicit filter-lang for cql searches

### DIFF
--- a/src/pages/Explore/utils/hooks/useStacFilter.ts
+++ b/src/pages/Explore/utils/hooks/useStacFilter.ts
@@ -11,6 +11,7 @@ export const makeFilterBody = (
   limit: number | undefined = undefined
 ): IStacFilter => {
   return {
+    "filter-lang": "cql-json",
     filter: { and: [...baseFilter, ...(query.cql || [])] },
     sortby: query.sortby || undefined,
     limit: limit,


### PR DESCRIPTION
The new pgstac backend supports both cql-json and cql2-json. This
version of Explorer generates cql-json and needs to specify the version
so pgstac interprets it correctly.

Note that the current DEP deployment works without this patch, due to a default
setting in pgstac, but that may change intermittently due to https://github.com/stac-utils/pgstac/issues/77 and
this patch would ensure it works regardless of the default setting.


You may also consider updating from the staging api endpoint to our
production endpoint, which is generally more stable:
https://github.com/developmentseed/PlanetaryComputerDataCatalog/blob/fee06b4036e6b5487ee1c72bd7443437b08918ce/.github/workflows/temporary_build.yaml#L19