### PR TITLE
point to planetary computer production endpoint, not staging

### DIFF
--- a/.github/workflows/temporary_build.yaml
+++ b/.github/workflows/temporary_build.yaml
@@ -16,7 +16,7 @@ jobs:
       - run: yarn install
       - run: yarn build
         env:
-          REACT_APP_API_ROOT: "https://planetarycomputer-staging.microsoft.com"
+          REACT_APP_API_ROOT: "https://planetarycomputer.microsoft.com"
           REACT_APP_AZMAPS_KEY: ${{ secrets.REACT_APP_AZMAPS_KEY }}
       - uses: bacongobbler/azure-blob-storage-upload@v1.2.0
         with:


### PR DESCRIPTION
- we are using `develop` branch as a production branch at this point, so it will make sense to point to planetary computer production instead of staging.  We can revisit this when we need more than production instance.
- I wonder this will help slowish tile loading? (related: https://github.com/developmentseed/digital-earth-pacific/issues/13#event-5801587498)