### PR TITLE
give option to hide in dataset.yml

### DIFF
--- a/src/config/datasets.yml
+++ b/src/config/datasets.yml
@@ -36,6 +36,7 @@ collections:
 
   3dep-seamless:
     category: DEMs
+    hide: True
     headerImg: ./images/threedep-seamless-hero.png
     tabs:
       - title: Example Notebook
@@ -68,6 +69,7 @@ collections:
 
   chloris-biomass:
     category: Biomass
+    hide: True
     headerImg: ./images/chloris-biomass-hero.jpg
     tabs:
       - title: Example Notebook
@@ -206,6 +208,7 @@ collections:
 
   goes-cmi:
     category: Imagery
+    hide: True
     headerImg: ./images/goes-cmi-hero.png
     tabs:
       - title: Example Notebook

--- a/src/config/datasets.yml
+++ b/src/config/datasets.yml
@@ -36,7 +36,7 @@ collections:
 
   3dep-seamless:
     category: DEMs
-    hide: True
+    hide: true
     headerImg: ./images/threedep-seamless-hero.png
     tabs:
       - title: Example Notebook
@@ -69,7 +69,7 @@ collections:
 
   chloris-biomass:
     category: Biomass
-    hide: True
+    hide: true
     headerImg: ./images/chloris-biomass-hero.jpg
     tabs:
       - title: Example Notebook
@@ -208,7 +208,7 @@ collections:
 
   goes-cmi:
     category: Imagery
-    hide: True
+    hide: true
     headerImg: ./images/goes-cmi-hero.png
     tabs:
       - title: Example Notebook

--- a/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
+++ b/src/pages/Explore/components/Sidebar/selectors/CollectionSelector.tsx
@@ -45,7 +45,9 @@ export default CollectionSelector;
 const depDataCategoryName = 'Digital Earth Pacific'
 
 const sortedOptions = (collections: IStacCollection[]) => {
-  const renderable = collections.filter(isValidExplorer).map(c => ({
+  const renderable = collections.filter(isValidExplorer)
+  .filter(c => collectionConfig[c.id]?.hide !== true)
+  .map(c => ({
     text: c.title,
     key: c.id,
     category: collectionConfig[c.id]?.category || "Other",


### PR DESCRIPTION
Manually hiding some datasets that we cannot automatically detect whether the data covers dep area or not. 

Put this in `dataset.yml` hoping it is easy for dep team to manually edit it if they need to.