### PR TITLE
replace hardcoded renderoption value

### DIFF
--- a/public/stac/sentinel-2-cloudless/mosaicInfo.json
+++ b/public/stac/sentinel-2-cloudless/mosaicInfo.json
@@ -25,7 +25,7 @@
     {
       "name": "4 Band RGB Images",
       "description": "4 band RGB Images",
-      "options": "assets=SWIR&bidx=1,3,5&nodata=0&skipcovered=False&exitwhenfull=False&items_limit=15&time_limit=5&color_formula=gamma RGB 2.7, saturation 1.2, sigmoidal RGB 15 0.55",
+      "options": "bidx=1&bidx=2&bidx=3&nodata=0&unscale=false&resampling=nearest&max_size=1024&return_mask=true",
       "minZoom": 3
     }
   ],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -175,7 +175,7 @@ export const makeTileJsonUrl = (
 
   // hard code tile url for dep data
   if (query.dep) {
-    return `https://dep-pctitiler.westeurope.cloudapp.azure.com/${query.format}/tiles/{z}/{x}/{y}.png?url=${query.url}&bidx=1&bidx=2&bidx=3&nodata=0&unscale=false&resampling=nearest&max_size=1024&return_mask=true`
+    return `https://dep-pctitiler.westeurope.cloudapp.azure.com/${query.format}/tiles/{z}/{x}/{y}.png?url=${query.url}&${renderParams}`
   }
 
   // Rendering a single Item

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -175,7 +175,7 @@ export const makeTileJsonUrl = (
 
   // hard code tile url for dep data
   if (query.dep) {
-    return `https://dep-pctitiler.westeurope.cloudapp.azure.com/${query.format}/tiles/{z}/{x}/{y}.png?url=${query.url}&${renderParams}`
+    return `https://dep-pctitiler.westeurope.cloudapp.azure.com/${query.format}/tiles/{z}/{x}/{y}.png?url=${query.url}&${renderParams}${minZoom}${format}`
   }
 
   // Rendering a single Item


### PR DESCRIPTION
I missed this hardcoded render option value for dep data last time, fixing it now. 
@wildintellect  I believe this should fix the problem in #26  (when I test, I can see that unnecessary query parameters is gone but the explorer still can't seem to load the tile? edit: I was at just wrong zoom level) 