### PR TITLE
make sync value string

### DIFF
--- a/.github/workflows/temporary_build.yaml
+++ b/.github/workflows/temporary_build.yaml
@@ -23,5 +23,5 @@ jobs:
           source_dir: build
           container_name: $web
           connection_string: ${{ secrets.STORAGE_CONNECTION_STRING }}
-          sync: false
+          sync: 'false'
           overwrite: 'true'


### PR DESCRIPTION
previous pr (https://github.com/developmentseed/PlanetaryComputerDataCatalog/pull/30) failed to fix the problem (https://github.com/developmentseed/PlanetaryComputerDataCatalog/actions/runs/2189837229). I read that github action doesn't handle boolean value properly for some reasons? https://github.com/bacongobbler/azure-blob-storage-upload/issues/24 🙏 